### PR TITLE
Add employee fields and preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,4 @@ cd leaveapp
 go run main.go
 ```
 
-Open `http://localhost:8080` in your browser to submit and view leave requests.
-The server will serve jQuery and a small dialog plugin from the static folder.
+Open `http://localhost:8080` in your browser to submit and view leave requests. All JavaScript (a minimal jQuery subset and the dialog plugin) is served locally from the `static` directory.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # jasper-tools
+
+This repository now includes a simple web-based leave management system written in Go.
+
+The form collects an employee's ID, position, department, leave type, start and end dates, and the reason for the leave. Before saving, the information is previewed in a jQuery-powered dialog so you can confirm it.
+
+## Running the leave app
+
+1. Create a SQLite database file named `leaves.db` and create a table:
+
+```sql
+CREATE TABLE IF NOT EXISTS requests (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    emp_id TEXT,
+    position TEXT,
+    department TEXT,
+    type TEXT,
+    start_date TEXT,
+    end_date TEXT,
+    reason TEXT
+);
+```
+
+2. Start the server:
+
+```bash
+cd leaveapp
+go run main.go
+```
+
+Open `http://localhost:8080` in your browser to submit and view leave requests.
+The server will serve jQuery and a small dialog plugin from the static folder.

--- a/leaveapp/go.mod
+++ b/leaveapp/go.mod
@@ -1,0 +1,5 @@
+module leaveapp
+
+go 1.23.8
+
+require github.com/mattn/go-sqlite3 v1.14.21

--- a/leaveapp/main.go
+++ b/leaveapp/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	_ "github.com/mattn/go-sqlite3"
+	"html/template"
+	"log"
+	"net/http"
+)
+
+type LeaveRequest struct {
+	ID         int
+	Name       string
+	EmpID      string
+	Position   string
+	Department string
+	Type       string
+	StartDate  string
+	EndDate    string
+	Reason     string
+}
+
+var tmpl = template.Must(template.ParseFiles("static/index.html"))
+
+func main() {
+	db, err := sql.Open("sqlite3", "leaves.db")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS requests (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT,
+                emp_id TEXT,
+                position TEXT,
+                department TEXT,
+                type TEXT,
+                start_date TEXT,
+                end_date TEXT,
+                reason TEXT
+        )`); err != nil {
+		log.Fatal(err)
+	}
+
+	http.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("static"))))
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		tmpl.Execute(w, nil)
+	})
+
+	http.HandleFunc("/requests", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			if err := r.ParseForm(); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			_, err := db.Exec("INSERT INTO requests(name, emp_id, position, department, type, start_date, end_date, reason) VALUES(?,?,?,?,?,?,?,?)",
+				r.FormValue("name"), r.FormValue("empid"), r.FormValue("position"), r.FormValue("department"), r.FormValue("type"), r.FormValue("start"), r.FormValue("end"), r.FormValue("reason"))
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			fmt.Fprintln(w, "OK")
+		case http.MethodGet:
+			rows, err := db.Query("SELECT id, name, emp_id, position, department, type, start_date, end_date, reason FROM requests")
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			defer rows.Close()
+			var list []LeaveRequest
+			for rows.Next() {
+				var lr LeaveRequest
+				if err := rows.Scan(&lr.ID, &lr.Name, &lr.EmpID, &lr.Position, &lr.Department, &lr.Type, &lr.StartDate, &lr.EndDate, &lr.Reason); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				list = append(list, lr)
+			}
+			tmpl.Execute(w, list)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	log.Println("Server started on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/leaveapp/static/index.html
+++ b/leaveapp/static/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Leave Management</title>
+    <script src="/static/jquery.min.js"></script>
+    <script src="/static/jquery.dialog.js"></script>
+    <style>
+    .dlg-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.3);display:flex;align-items:center;justify-content:center;}
+    .dlg-box{background:#fff;padding:1em;border:1px solid #666;}
+    .dlg-buttons{text-align:right;margin-top:1em;}
+    </style>
+</head>
+<body>
+<h1>請假申請</h1>
+<form id="leaveForm">
+    姓名：<input type="text" name="name"><br>
+    員工編號：<input type="text" name="empid"><br>
+    職稱：<input type="text" name="position"><br>
+    部門：<input type="text" name="department"><br>
+    請假種類：<select name="type">
+        <option value="事假">事假</option>
+        <option value="病假">病假</option>
+        <option value="特休">特休</option>
+        <option value="補休">補休</option>
+        <option value="喪假">喪假</option>
+        <option value="婚假">婚假</option>
+        <option value="育兒假">育兒假</option>
+    </select><br>
+    開始日期：<input type="date" name="start"><br>
+    結束日期：<input type="date" name="end"><br>
+    事由：<input type="text" name="reason"><br>
+    <button type="submit">送出</button>
+</form>
+<div id="previewDialog" style="display:none">
+    <pre id="previewText"></pre>
+</div>
+<h2>申請紀錄</h2>
+<ul id="list">
+    {{range .}}
+    <li>{{.Name}} ({{.EmpID}}/{{.Position}}/{{.Department}}/{{.Type}})：{{.StartDate}} - {{.EndDate}}：{{.Reason}}</li>
+    {{end}}
+</ul>
+<script>
+$(function(){
+    function load(){
+        $.get('/requests', function(data){
+            $('#list').html($(data).find('li'));
+        });
+    }
+    load();
+    $('#leaveForm').on('submit', function(e){
+        e.preventDefault();
+        var f = this;
+        var preview =
+            '姓名: ' + f.name.value + '\n' +
+            '員工編號: ' + f.empid.value + '\n' +
+            '職稱: ' + f.position.value + '\n' +
+            '部門: ' + f.department.value + '\n' +
+            '請假種類: ' + f.type.value + '\n' +
+            '開始日期: ' + f.start.value + '\n' +
+            '結束日期: ' + f.end.value + '\n' +
+            '事由: ' + f.reason.value;
+        $('#previewText').text(preview);
+        $('#previewDialog').dialog({
+            buttons:{
+                '取消': function(){},
+                '送出': function(){
+                    $.post('/requests', $(f).serialize(), function(){
+                        load();
+                        f.reset();
+                    });
+                }
+            }
+        });
+    });
+});
+</script>
+</body>
+</html>

--- a/leaveapp/static/jquery.dialog.js
+++ b/leaveapp/static/jquery.dialog.js
@@ -1,0 +1,30 @@
+(function($){
+  $.fn.dialog = function(opts){
+    return this.each(function(){
+      var $self = $(this);
+      var placeholder = $('<span style="display:none"></span>');
+      $self.after(placeholder);
+      var overlay = $('<div class="dlg-overlay"></div>').css({
+        position:'fixed',top:0,left:0,right:0,bottom:0,
+        background:'rgba(0,0,0,0.3)',display:'flex',
+        'align-items':'center','justify-content':'center'
+      });
+      var box = $('<div class="dlg-box"></div>').css({
+        background:'#fff',padding:'1em',border:'1px solid #666'
+      });
+      var btns = $('<div class="dlg-buttons"></div>').css({'text-align':'right','margin-top':'1em'});
+      var close = function(){ overlay.remove(); placeholder.after($self.hide()); placeholder.remove(); };
+      if(opts && opts.buttons){
+        Object.keys(opts.buttons).forEach(function(name){
+          $('<button type="button"></button>').text(name).on('click',function(){
+            close();
+            opts.buttons[name].call($self[0]);
+          }).appendTo(btns);
+        });
+      }
+      box.append($self.show()).append(btns);
+      overlay.append(box).appendTo('body');
+      $self.data('dlg-overlay', overlay);
+    });
+  };
+})(jQuery);

--- a/leaveapp/static/jquery.min.js
+++ b/leaveapp/static/jquery.min.js
@@ -1,0 +1,29 @@
+/*! Minimal jQuery-like subset for local use */
+(function(w,d){
+function $(s){
+  if(typeof s==='function')return ready(s);
+  if(s instanceof jQuery)return s;
+  var els=[];
+  if(typeof s==='string'){
+    if(s.trim().charAt(0)==='<'){
+      var div=d.createElement('div');
+      div.innerHTML=s;els=Array.from(div.childNodes);
+    }else{els=Array.from(d.querySelectorAll(s));}
+  }else if(s instanceof Node||s===w){els=[s];}
+  return new jQuery(els);
+}
+function jQuery(els){this.els=els;}
+jQuery.prototype={html:function(v){
+  if(v===undefined)return this.els[0]&&this.els[0].innerHTML;
+  this.els.forEach(function(e){e.innerHTML=v;});return this;},
+ find:function(s){var r=[];this.els.forEach(function(e){r=r.concat(Array.from(e.querySelectorAll(s)));});return $(r);},
+ on:function(ev,fn){this.els.forEach(function(e){e.addEventListener(ev,fn);});return this;},
+ serialize:function(){var f=this.els[0];return new URLSearchParams(new FormData(f)).toString();}
+};
+function ajax(m,u,dta,cb){var x=new XMLHttpRequest();x.open(m,u,true);x.setRequestHeader('Content-Type','application/x-www-form-urlencoded');x.onload=function(){cb&&cb(x.responseText);};x.send(dta);}
+$.get=function(u,cb){ajax('GET',u,null,cb);};
+$.post=function(u,dta,cb){ajax('POST',u,dta,cb);};
+function ready(fn){if(d.readyState!=='loading')fn();else d.addEventListener('DOMContentLoaded',fn);}
+$.ready=ready;
+w.$=$;w.jQuery=$;
+})(window,document);


### PR DESCRIPTION
## Summary
- expand leave request struct with employee data and leave type
- update database schema and insertion logic
- extend form and request list with new fields
- show confirmation preview before saving
- document new fields and schema in README
- use jQuery dialog for preview with cancel/submit buttons

## Testing
- `gofmt -w leaveapp/main.go`
- `go build ./...` *(fails: missing go.sum entry for github.com/mattn/go-sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_684c0cf1076c8327ae4644f9392f9464